### PR TITLE
build: add basic ICommand.hpp

### DIFF
--- a/includes/ICommand.hpp
+++ b/includes/ICommand.hpp
@@ -1,0 +1,15 @@
+#ifndef ICOMMAND_HPP
+# define ICOMMAND_HPP
+# include <iostream>
+
+class ICommand
+{
+    public:
+        ICommand(void);
+        ICommand(const ICommand& other);
+        ICommand &operator=(const ICommand &other);
+        ~ICommand();
+};
+
+#endif
+


### PR DESCRIPTION
Simple ICommand.hpp added in includes. It only contains canonical orthodoxe form contructors. First try of pull request.