### PR TITLE
fix: Nickame can hold specials characters for first characters (and after)

### DIFF
--- a/includes/commands/Join.hpp
+++ b/includes/commands/Join.hpp
@@ -13,7 +13,7 @@ struct ChannelParam {
 	std::string channel;
 	std::string key;
 	bool		isValid;
-	ChannelParam(const std::string& a, std::string& b) : channel(a), key(b), isValid(true) {}
+	ChannelParam(const std::string& a, std::string& b) : channel(a), key(b), isValid(true) {} //to be define in .cpp ???
 	ChannelParam(const std::string& a) : channel(a), isValid(true) {}
 	ChannelParam(const std::string& a, bool valid) : channel(a), isValid(valid) {}
 };

--- a/includes/utils.hpp
+++ b/includes/utils.hpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <string>
 
+bool is_special_abnf(char c);
 bool check_args(int ac, char** av, int* port);
 bool check_port(const std::string& s, int* port);
 bool check_password(const std::string& s);

--- a/srcs/commands/Nick.cpp
+++ b/srcs/commands/Nick.cpp
@@ -1,4 +1,5 @@
 #include "Nick.hpp"
+#include "utils.hpp"
 
 #include "Client.hpp"
 #include "Config.hpp"
@@ -42,7 +43,7 @@ ReplyCode Nick::check_args(Server& server, Client& client, std::string& params)
 	if (nickname.empty()) {
 		LOG_CMD.error("431 ERR_NONICKNAMEGIVEN");
 		return (ERR_NONICKNAMEGIVEN);
-	} else if (!std::isalpha(nickname[0])) {
+	} else if (!std::isalpha(nickname[0]) && !is_special_abnf(nickname[0])) {
 		LOG_CMD.error("432 ERR_ERRONEUSNICKNAME");
 		return (ERR_ERRONEUSNICKNAME);
 	} else if (nickname.length() > ircConfig.get_nickname_max_len()) {

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -5,8 +5,8 @@
 
 bool is_special_abnf(char c) {
     unsigned char uc = (unsigned char)c;
-    return (uc >= 0x5B && uc <= 0x60) ||
-           (uc >= 0x7B && uc <= 0x7D);
+    return (uc >= '[' && uc <= '`') ||
+           (uc >= '{' && uc <= '}');
 }
 
 bool check_port(const std::string& s, int* port)

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -3,6 +3,12 @@
 #include "LogManager.hpp"
 #include "consts.hpp"
 
+bool is_special_abnf(char c) {
+    unsigned char uc = (unsigned char)c;
+    return (uc >= 0x5B && uc <= 0x60) ||
+           (uc >= 0x7B && uc <= 0x7D);
+}
+
 bool check_port(const std::string& s, int* port)
 {
 	long n = utils::string_to_ulong(s.c_str());


### PR DESCRIPTION
add is_special_abnf(char c) in utils to know if the characters is special according to abnf (use for nickname validation)